### PR TITLE
Linux module extra

### DIFF
--- a/docker/init.sls
+++ b/docker/init.sls
@@ -11,7 +11,7 @@ docker-dependencies:
 docker-kernel-dependencies:
   pkg.installed:
     - pkgs:
-      - linux-image-extra-{{ salt['grains.get']('kernelrelease') }}
+      - linux-modules-extra-{{ salt['grains.get']('kernelrelease') }}
     - unless: grep aufs /proc/filesystems
 
 docker-pkg:

--- a/docker/init.sls
+++ b/docker/init.sls
@@ -7,13 +7,19 @@ docker-dependencies:
   pkg.installed:
     - pkgs:
       - ca-certificates
+
+docker-kernel-dependencies:
+  pkg.installed:
+    - pkgs:
       - linux-image-extra-{{ salt['grains.get']('kernelrelease') }}
+    - unless: grep aufs /proc/filesystems
 
 docker-pkg:
   pkg.installed:
     - name: {{ docker.pkg }}-{{ docker.pkg_version }}
     - require:
       - pkg: docker-dependencies
+      - pkg: docker-kernel-dependencies
       - pkgrepo: docker_repo
       - kmod: aufs
 


### PR DESCRIPTION
This PR fixes the issue with the linux-image-extra package.

_Background_:
The linux-image-extra was renamed to linux-modules-extra and it comes with the aufs which is prerequisite for old docker versions.

This renaming causes the docker salt state to fail, meaning that docker is not getting installed in the ec2 boxes.